### PR TITLE
[WIP/MNT] - Add CI testing of python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       MODULE_NAME: convnwb
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,8 @@ convnwb
 Overview
 --------
 
-This module contains general, task agnostic, utilities, for converting data to NWB format.
+This module contains general, task agnostic, utilities, for converting data to the
+`NWB <https://www.nwb.org/>`_ format.
 
 Available sub-modules in `convnwb` include:
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     platforms = 'any',
     project_urls = {},


### PR DESCRIPTION
Update to run CI tests against Python 3.11. 

This is waiting on updates for some dependencies including h5py, see:
https://github.com/h5py/h5py/issues/2146