### PR TITLE
 [MNT] - Build & install related updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ doc/generated/
 
 # Ignore module build files
 build/*
-convnwb.egg-info/*
+*.egg-info/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -28,50 +28,50 @@ LINT_FILE   = _lint.txt
 
 # Run all counts
 run-counts:
-    @make count-size
-    @make count-module
-    @make count-tests
+	@make count-size
+	@make count-module
+	@make count-tests
 
 # Count the total number of lines in the module
 count-size:
-    @printf "\n\nCHECK MODULE SIZE:"
-    @printf "\nNumber of lines of code & comments in the module: "
-    @find ./$(MODULE) -name "*.py" -type f -exec grep . {} \; | wc -l
+	@printf "\n\nCHECK MODULE SIZE:"
+	@printf "\nNumber of lines of code & comments in the module: "
+	@find ./$(MODULE) -name "*.py" -type f -exec grep . {} \; | wc -l
 
 # Count module code with CLOC, excluding test files
 count-module:
-    @printf "\n\nCLOC OUTPUT - MODULE: \n"
-    @cloc $(MODULE) --exclude-dir='tests'
+	@printf "\n\nCLOC OUTPUT - MODULE: \n"
+	@cloc $(MODULE) --exclude-dir='tests'
 
 # Count test code, with CLOC
 count-tests:
-    @printf "\n\nCLOC OUTPUT - TEST FILES: \n"
-    @cloc $(MODULE)/tests --exclude-dir='test_files'
+	@printf "\n\nCLOC OUTPUT - TEST FILES: \n"
+	@cloc $(MODULE)/tests --exclude-dir='test_files'
 
 ##########################################################################
 ## CODE TESTING
 
 # Run all tests
 run-tests:
-    @make coverage
-    #@make doctests
+	@make coverage
+	#@make doctests
 
 # Run tests
 tests:
-    @printf "\n\nRUN TESTS: \n"
-    @pytest
+	@printf "\n\nRUN TESTS: \n"
+	@pytest
 
 # Run test coverage
 coverage:
-    @printf "\n\nRUN TESTS: \n"
-    @coverage run --source $(MODULE) -m py.test
-    @printf "\n\nCHECK COVERAGE: \n"
-    @coverage report --omit="*/tests*"
+	@printf "\n\nRUN TESTS: \n"
+	@coverage run --source $(MODULE) -m py.test
+	@printf "\n\nCHECK COVERAGE: \n"
+	@coverage report --omit="*/tests*"
 
 # Run doctests
 doctests:
-    @printf "\n\nCHECK DOCTEST EXAMPLES: \n"
-    @pytest --doctest-modules --ignore=$(MODULE)/tests $(MODULE)
+	@printf "\n\nCHECK DOCTEST EXAMPLES: \n"
+	@pytest --doctest-modules --ignore=$(MODULE)/tests $(MODULE)
 
 ##########################################################################
 ## CODE LINTING
@@ -80,44 +80,44 @@ doctests:
 #   Note: --exit-zero is because pylint throws an error when called
 #     from a Makefile. Unclear why, but this avoids it stopping.
 run-lints:
-    @printf "\n\nRUN PYLINT ACROSS MODULE: \n"
-    @pylint $(MODULE) --ignore tests --exit-zero  > $(LINT_FILE)
-    @tail -n4 $(LINT_FILE)
+	@printf "\n\nRUN PYLINT ACROSS MODULE: \n"
+	@pylint $(MODULE) --ignore tests --exit-zero  > $(LINT_FILE)
+	@tail -n4 $(LINT_FILE)
 
 ##########################################################################
 ## SUMMARY
 
 # Run a summary of the module
 summary:
-    @make run-counts
-    @make run-tests
-    @make run-lints
+	@make run-counts
+	@make run-tests
+	@make run-lints
 
 ##########################################################################
 ## DISTRIBUTION
 
 # Create a distribution build of the module
 dist:
-    @printf "\n\nCREATING DISTRIBUTION BUILD...\n"
-    @python -m build
-    @printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
+	@printf "\n\nCREATING DISTRIBUTION BUILD...\n"
+	@python -m build
+	@printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
 
 # Check a distribution build using twine
 check-dist:
-    @printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
-    @twine check dist/*
-    @printf "\n"
+	@printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
+	@twine check dist/*
+	@printf "\n"
 
 # Clear out distribution files
 clear-dist:
-    @printf "\n\nCLEARING DISTRIBUTION FILES...\n"
-    @rm -rf build dist $(MODULE).egg-info
-    @printf "DISTRIBUTION FILES CLEARED\n\n\n"
+	@printf "\n\nCLEARING DISTRIBUTION FILES...\n"
+	@rm -rf build dist $(MODULE).egg-info
+	@printf "DISTRIBUTION FILES CLEARED\n\n\n"
 
 # Show commands for publishing the distribution
 #   Note: this doesn't run the commands (to avoid accidental publishing)
 #   This also assumes that you are using twine + .pypirc
 publish:
-    @printf "\n\nTO PUBLISH THE DISTRIBUTION:\n\n"
-    @printf "to testpypi: \n\ttwine upload --repository testpypi dist/*\n"
-    @printf "to pypi: \n\ttwine upload --repository pypi dist/*\n\n"
+	@printf "\n\nTO PUBLISH THE DISTRIBUTION:\n\n"
+	@printf "to testpypi: \n\ttwine upload --repository testpypi dist/*\n"
+	@printf "to pypi: \n\ttwine upload --repository pypi dist/*\n\n"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 #   coverage            For running test coverage
 #   pylint              For running linting on code
 #   setuptools          For creating distributions
-#   twine		For checking and publishing distributions
+#   build               For creating distributions
+#   twine               For checking and publishing distributions
 #
 # The following command line utilities are required:
 #   cloc                For counting code
@@ -27,50 +28,50 @@ LINT_FILE   = _lint.txt
 
 # Run all counts
 run-counts:
-	@make count-size
-	@make count-module
-	@make count-tests
+    @make count-size
+    @make count-module
+    @make count-tests
 
 # Count the total number of lines in the module
 count-size:
-	@printf "\n\nCHECK MODULE SIZE:"
-	@printf "\nNumber of lines of code & comments in the module: "
-	@find ./$(MODULE) -name "*.py" -type f -exec grep . {} \; | wc -l
+    @printf "\n\nCHECK MODULE SIZE:"
+    @printf "\nNumber of lines of code & comments in the module: "
+    @find ./$(MODULE) -name "*.py" -type f -exec grep . {} \; | wc -l
 
 # Count module code with CLOC, excluding test files
 count-module:
-	@printf "\n\nCLOC OUTPUT - MODULE: \n"
-	@cloc $(MODULE) --exclude-dir='tests'
+    @printf "\n\nCLOC OUTPUT - MODULE: \n"
+    @cloc $(MODULE) --exclude-dir='tests'
 
 # Count test code, with CLOC
 count-tests:
-	@printf "\n\nCLOC OUTPUT - TEST FILES: \n"
-	@cloc $(MODULE)/tests --exclude-dir='test_files'
+    @printf "\n\nCLOC OUTPUT - TEST FILES: \n"
+    @cloc $(MODULE)/tests --exclude-dir='test_files'
 
 ##########################################################################
 ## CODE TESTING
 
 # Run all tests
 run-tests:
-	@make coverage
-	#@make doctests
+    @make coverage
+    #@make doctests
 
 # Run tests
 tests:
-	@printf "\n\nRUN TESTS: \n"
-	@pytest
+    @printf "\n\nRUN TESTS: \n"
+    @pytest
 
 # Run test coverage
 coverage:
-	@printf "\n\nRUN TESTS: \n"
-	@coverage run --source $(MODULE) -m py.test
-	@printf "\n\nCHECK COVERAGE: \n"
-	@coverage report --omit="*/tests*"
+    @printf "\n\nRUN TESTS: \n"
+    @coverage run --source $(MODULE) -m py.test
+    @printf "\n\nCHECK COVERAGE: \n"
+    @coverage report --omit="*/tests*"
 
 # Run doctests
 doctests:
-	@printf "\n\nCHECK DOCTEST EXAMPLES: \n"
-	@pytest --doctest-modules --ignore=$(MODULE)/tests $(MODULE)
+    @printf "\n\nCHECK DOCTEST EXAMPLES: \n"
+    @pytest --doctest-modules --ignore=$(MODULE)/tests $(MODULE)
 
 ##########################################################################
 ## CODE LINTING
@@ -79,44 +80,44 @@ doctests:
 #   Note: --exit-zero is because pylint throws an error when called
 #     from a Makefile. Unclear why, but this avoids it stopping.
 run-lints:
-	@printf "\n\nRUN PYLINT ACROSS MODULE: \n"
-	@pylint $(MODULE) --ignore tests --exit-zero  > $(LINT_FILE)
-	@tail -n4 $(LINT_FILE)
+    @printf "\n\nRUN PYLINT ACROSS MODULE: \n"
+    @pylint $(MODULE) --ignore tests --exit-zero  > $(LINT_FILE)
+    @tail -n4 $(LINT_FILE)
 
 ##########################################################################
 ## SUMMARY
 
 # Run a summary of the module
 summary:
-	@make run-counts
-	@make run-tests
-	@make run-lints
+    @make run-counts
+    @make run-tests
+    @make run-lints
 
 ##########################################################################
 ## DISTRIBUTION
 
 # Create a distribution build of the module
 dist:
-	@printf "\n\nCREATING DISTRIBUTION BUILD...\n"
-	@python setup.py sdist bdist_wheel
-	@printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
+    @printf "\n\nCREATING DISTRIBUTION BUILD...\n"
+    @python -m build
+    @printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
 
 # Check a distribution build using twine
 check-dist:
-	@printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
-	twine check dist/*
-	@printf "\n"
+    @printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
+    @twine check dist/*
+    @printf "\n"
 
 # Clear out distribution files
 clear-dist:
-	@printf "\n\nCLEARING DISTRIBUTION FILES...\n"
-	@rm -rf build dist $(MODULE).egg-info
-	@printf "DISTRIBUTION FILES CLEARED\n\n\n"
+    @printf "\n\nCLEARING DISTRIBUTION FILES...\n"
+    @rm -rf build dist $(MODULE).egg-info
+    @printf "DISTRIBUTION FILES CLEARED\n\n\n"
 
 # Show commands for publishing the distribution
 #   Note: this doesn't run the commands (to avoid accidental publishing)
 #   This also assumes that you are using twine + .pypirc
 publish:
-	@printf "\n\nTO PUBLISH THE DISTRIBUTION:\n\n"
-	@printf "to testpypi: \n\ttwine upload --repository testpypi dist/*\n"
-	@printf "to pypi: \n\ttwine upload --repository pypi dist/*\n\n"
+    @printf "\n\nTO PUBLISH THE DISTRIBUTION:\n\n"
+    @printf "to testpypi: \n\ttwine upload --repository testpypi dist/*\n"
+    @printf "to pypi: \n\ttwine upload --repository pypi dist/*\n\n"

--- a/convnwb/tests/tsettings.py
+++ b/convnwb/tests/tsettings.py
@@ -1,13 +1,14 @@
 """Settings for tests."""
 
+import os
 from pathlib import Path
-import pkg_resources as pkg
 
 ###################################################################################################
 ###################################################################################################
 
 # Set base test files path
-BASE_TEST_OUTPUTS_PATH = Path(pkg.resource_filename(__name__, 'test_outputs'))
+TESTS_PATH = Path(os.path.abspath(os.path.dirname(__file__)))
+BASE_TEST_OUTPUTS_PATH = TESTS_PATH / 'test_outputs'
 
 # Set paths for test files, separated by type
 TEST_FILE_PATH = BASE_TEST_OUTPUTS_PATH / 'test_files'

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version = __version__,
     description = 'Helper code for converting data to NWB.',
     long_description = long_description,
+    long_description_content_type = 'text/x-rst',
     python_requires = '>=3.6',
     packages = find_packages(),
     license = 'MIT License',
@@ -41,9 +42,19 @@ setup(
         'Programming Language :: Python :: 3.11',
     ],
     platforms = 'any',
-    project_urls = {},
-    download_url = 'https://github.com/JacobsSU/convnwb/releases',
+    project_urls = {
+        'Documentation' : 'https://hsupipeline.github.io/convnwb/',
+        'Bug Reports' : 'https://github.com/HSUPipeline/convnwb/issues',
+        'Source' : 'https://github.com/HSUPipeline/convnwb',
+    },
+    download_url = 'https://github.com/HSUPipeline/convnwb/releases',
     keywords = ['neuroscience', 'single units', 'data management', 'neurodata without borders'],
     install_requires = install_requires,
     tests_require = ['pytest'],
+    extras_require = {
+        'compute' : ['scipy', 'scikit-learn'],
+        'data' : ['pandas', 'h5py', 'pynwb'],
+        'plot' : ['matplotlib'],
+        'all' : ['scipy', 'scikit-learn', 'pandas', 'h5py', 'pynwb', 'matplotlib'],
+    }
 )


### PR DESCRIPTION
Updates:
- use `build` for distributions (see https://github.com/fooof-tools/fooof/pull/282/)
- drop use of `package_resources` (see https://github.com/fooof-tools/fooof/pull/281)