### PR TITLE
[MNT] - Update actions ubuntu image and drop python 3.6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,14 @@ on:
 jobs:
   build:
 
-    # Tag ubuntu version to 20.04, in order to support python 3.6
-    #   See issue: https://github.com/actions/setup-python/issues/544
-    #   When ready to drop 3.6, can revert from 'ubuntu-20.04' -> 'ubuntu-latest'
-    runs-on: ubuntu-20.04
+    # Tag ubuntu image version to 22.04 in order to support python 3.7
+    #   When dropping 3.7, can update release (to 'ubuntu-24.04' or 'ubuntu-latest')
+    runs-on: ubuntu-22.04
     env:
       MODULE_NAME: convnwb
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -41,4 +40,3 @@ jobs:
       uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description = 'Helper code for converting data to NWB.',
     long_description = long_description,
     long_description_content_type = 'text/x-rst',
-    python_requires = '>=3.6',
+    python_requires = '>=3.7',
     packages = find_packages(),
     license = 'MIT License',
     classifiers = [
@@ -34,7 +34,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Unix',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Drops deprecated ubuntu image ('ubuntu-20.04') and correspondingly updates minimum Python version to 3.7 (since 3.6 is no longer supported on the actions tests).